### PR TITLE
Ensure railtie adds middleware after config initializers

### DIFF
--- a/lib/serviceworker/railtie.rb
+++ b/lib/serviceworker/railtie.rb
@@ -9,9 +9,8 @@ module ServiceWorker
     config.serviceworker.routes = ServiceWorker::Router.new
     config.serviceworker.handler = ServiceWorker::Rails::Handler.new
 
-    initializer "serviceworker-rails.configure_rails_initialization" do
+    initializer "serviceworker-rails.configure_rails_initialization", after: :load_config_initializers do
       config.serviceworker.logger ||= ::Rails.logger
-      config.serviceworker.routes.draw_default unless config.serviceworker.routes.any?
 
       app.middleware.use ServiceWorker::Middleware, config.serviceworker
     end

--- a/test/sample/app/assets/javascripts/fallback/serviceworker.js
+++ b/test/sample/app/assets/javascripts/fallback/serviceworker.js
@@ -1,0 +1,6 @@
+console.log('SW:', 'Hello from Fallback ServiceWorker!');
+
+self.addEventListener('fetch', function(event) {
+  console.log('SW:', 'fetching', event.request.url);
+  return;
+});

--- a/test/sample/config/application.rb
+++ b/test/sample/config/application.rb
@@ -30,18 +30,6 @@ module Sample
     # config.active_record.raise_in_transactional_callbacks = true
 
     config.serviceworker.headers["X-Custom-Header"] = "foobar"
-
-    config.serviceworker.routes.draw do
-      match "/serviceworker.js"
-
-      match "/header-serviceworker.js" => "another/serviceworker.js",
-        headers: { "X-Resource-Header" => "A resource" }
-
-      match "/nested/serviceworker.js",
-        asset: "another/serviceworker.js"
-
-      get "/*/serviceworker.js" => "serviceworker.js"
-    end
   end
 end
 

--- a/test/sample/config/initializers/serviceworker.rb
+++ b/test/sample/config/initializers/serviceworker.rb
@@ -1,0 +1,13 @@
+Rails.application.configure do
+  config.serviceworker.routes.draw_default
+
+  config.serviceworker.routes.draw do
+    match "/header-serviceworker.js" => "another/serviceworker.js",
+      headers: { "X-Resource-Header" => "A resource" }
+
+    match "/nested/serviceworker.js",
+      asset: "another/serviceworker.js"
+
+    get "/*/serviceworker.js" => "fallback/serviceworker.js"
+  end
+end

--- a/test/serviceworker/integration_test.rb
+++ b/test/serviceworker/integration_test.rb
@@ -49,7 +49,7 @@ class ServiceWorker::IntegrationTest < Minitest::Test
     get "/catchall/serviceworker.js"
 
     assert last_response.ok?
-    assert_match %r{console.log\(.*'Hello from ServiceWorker!'.*\);}, last_response.body
+    assert_match %r{console.log\(.*'Hello from Fallback ServiceWorker!'.*\);}, last_response.body
   end
 
   def test_not_found_serviceworker_proxy


### PR DESCRIPTION
Previously, the railtie added the SW middleware before the application `config/initializers` were run, so any routes added then would be ignored. Also removes the auto default route logic.