### PR TITLE
fix example in README to point to correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ middleware stack. You'll want to configure it by mapping serviceworker routes to
 Sprockets JavaScript assets, like the example below, in `application.rb`.
 
 ```ruby
-# config/initializers/serviceworker.rb
+# config/application.rb
 
 Rails.application.configure do
   config.serviceworker.routes.draw do


### PR DESCRIPTION
Hi,
just noticed this small confusion causing typo in the README.

Cheers,
Frank