### PR TITLE
Fix undefined variable error

### DIFF
--- a/lib/generators/serviceworker/templates/serviceworker.js
+++ b/lib/generators/serviceworker/templates/serviceworker.js
@@ -29,7 +29,7 @@ function onActivate(event) {
           // Return true if you want to remove this cache,
           // but remember that caches are shared across
           // the whole origin
-          return key.indexOf(CACHE_VERSION) !== 0;
+          return cacheName.indexOf(CACHE_VERSION) !== 0;
         }).map(function(cacheName) {
           return caches.delete(cacheName);
         })


### PR DESCRIPTION
Activating the service worker failed because "key" was not defined. Renamed the variable to "cacheName" to make it work as intended.