### PR TITLE
Fix cache name for activation logic to delete old caches

### DIFF
--- a/lib/generators/serviceworker/templates/serviceworker.js
+++ b/lib/generators/serviceworker/templates/serviceworker.js
@@ -1,5 +1,5 @@
-var CACHE_VERSION = 'v1'
-var CACHE_NAME = 'sw-cache-' + CACHE_VERSION;
+var CACHE_VERSION = 'v1';
+var CACHE_NAME = CACHE_VERSION + ':sw-cache-';
 
 function onInstall(event) {
   console.log('[Serviceworker]', "Installing!", event);


### PR DESCRIPTION
Fixes #27 

The generated `activate` function provides logic to delete old caches based on the `CACHE_VERSION`, which can be bumped at will. The filter logic expects the version to be prepended, not appended, to the `CACHE_NAME`.