### PR TITLE
Use compute asset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/rossta/serviceworker-rails.svg?branch=master)](https://travis-ci.org/rossta/serviceworker-rails)
 [![Code Climate](https://codeclimate.com/github/rossta/serviceworker-rails/badges/gpa.svg)](https://codeclimate.com/github/rossta/serviceworker-rails)
-[![Coverage Status](https://coveralls.io/repos/github/rossta/serviceworker-rails/badge.svg?branch=master)](https://coveralls.io/github/rossta/serviceworker-rails?branch=master)
 
 Turn your Rails app into a Progressive Web App. Use [Service Worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) with the Rails asset pipeline.
 

--- a/lib/generators/serviceworker/install_generator.rb
+++ b/lib/generators/serviceworker/install_generator.rb
@@ -35,7 +35,7 @@ module Serviceworker
         snippet = %(<link rel="manifest" href="/manifest.json" />)
         snippet << %(\n<meta name="apple-mobile-web-app-capable" content="yes">)
         unless layout
-          warn "Could not locate application layout. To insert manifest tags manually, use:\n\n#{snippet}\n"
+          conditional_warn "Could not locate application layout. To insert manifest tags manually, use:\n\n#{snippet}\n"
           return
         end
         insert_into_file layout, snippet, before: "</head>\n"
@@ -84,6 +84,14 @@ module Serviceworker
 
       def join(*paths)
         File.expand_path(File.join(*paths), destination_root)
+      end
+
+      def conditional_warn(warning)
+        silenced? or warn warning
+      end
+
+      def silenced?
+        ENV["RAILS_ENV"] == "test"
       end
     end
   end

--- a/lib/serviceworker/rails/handler.rb
+++ b/lib/serviceworker/rails/handler.rb
@@ -29,7 +29,15 @@ module ServiceWorker
       end
 
       def asset_path(path)
-        ::ActionController::Base.helpers.asset_path(path)
+        if controller_helpers.respond_to?(:compute_asset_path)
+          controller_helpers.compute_asset_path(path)
+        else
+          controller_helpers.asset_path(path, host: proc {})
+        end
+      end
+
+      def controller_helpers
+        ::ActionController::Base.helpers
       end
     end
   end

--- a/lib/serviceworker/rails/handler.rb
+++ b/lib/serviceworker/rails/handler.rb
@@ -32,12 +32,22 @@ module ServiceWorker
         if controller_helpers.respond_to?(:compute_asset_path)
           controller_helpers.compute_asset_path(path)
         else
-          controller_helpers.asset_path(path, host: proc {})
+          logical_asset_path(path)
         end
       end
 
       def controller_helpers
         ::ActionController::Base.helpers
+      end
+
+      def logical_asset_path(path)
+        asset_path = controller_helpers.asset_path(path)
+        uri = URI.parse(asset_path)
+        uri.host = nil
+        uri.scheme = nil
+        uri.to_s
+      rescue URI::InvalidURIError
+        asset_path
       end
     end
   end

--- a/serviceworker-rails.gemspec
+++ b/serviceworker-rails.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "0.46.0"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "appraisal", "~> 2.1.0"
-  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "simplecov"
 end

--- a/test/sample/config/environments/test.rb
+++ b/test/sample/config/environments/test.rb
@@ -58,4 +58,14 @@ Sample::Application.configure do
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
+
+  class TestAssetHost
+    cattr_accessor :host
+
+    def self.proc_method
+      proc { TestAssetHost.host }
+    end
+  end
+
+  config.action_controller.asset_host = TestAssetHost.proc_method
 end

--- a/test/serviceworker/rails_integration_test.rb
+++ b/test/serviceworker/rails_integration_test.rb
@@ -11,6 +11,10 @@ class ServiceWorker::RailsIntegrationTest < Minitest::Test
     get "/"
   end
 
+  def teardown
+    TestAssetHost.host = nil
+  end
+
   def test_homepage
     assert last_response.ok?
     assert_match(/Hello, World/, last_response.body)
@@ -82,6 +86,15 @@ class ServiceWorker::RailsIntegrationTest < Minitest::Test
       assert_equal "application/javascript", last_response.headers["Content-Type"]
       assert_equal "private, max-age=0, no-cache", last_response.headers["Cache-Control"]
       assert_match(/console.log\(.*'Hello from ServiceWorker!'.*\);/, last_response.body)
+    end
+  end
+
+  def test_cdn_asset_host
+    TestAssetHost.host = "https://assets.example.com"
+    Rails.application.config.assets.stub(:compile, false) do
+      get "/serviceworker.js"
+
+      assert last_response.ok?
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ ENV["RAILS_ENV"] = ENV["RACK_ENV"] = "test"
 require "simplecov"
 require "coveralls"
 SimpleCov.minimum_coverage 75
+SimpleCov.maximum_coverage_drop 25
 Coveralls.wear! do
   add_filter "test"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ ENV["RAILS_ENV"] = ENV["RACK_ENV"] = "test"
 
 require "simplecov"
 require "coveralls"
-SimpleCov.maximum_coverage_drop 5
+SimpleCov.minimum_coverage 75
 Coveralls.wear! do
   add_filter "test"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,12 +3,8 @@
 ENV["RAILS_ENV"] = ENV["RACK_ENV"] = "test"
 
 require "simplecov"
-require "coveralls"
 SimpleCov.minimum_coverage 75
 SimpleCov.maximum_coverage_drop 25
-Coveralls.wear! do
-  add_filter "test"
-end
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 


### PR DESCRIPTION
Fixes bug where serviceworker middleware is using the wrong url in Rails environments in which the `config.action_controller.asset_host` is configured to a remote server, such as a CDN.

Fixes #35 
Fixes #29 