### PR TITLE
Add icon sizes 144 and 384

### DIFF
--- a/lib/serviceworker/engine.rb
+++ b/lib/serviceworker/engine.rb
@@ -10,7 +10,7 @@ module ServiceWorker
     config.serviceworker.headers = {}
     config.serviceworker.routes = ServiceWorker::Router.new
     config.serviceworker.handler = :sprockets
-    config.serviceworker.icon_sizes = %w[36 48 60 72 76 96 120 152 180 192 512]
+    config.serviceworker.icon_sizes = %w[36 48 60 72 76 96 120 144 152 180 192 384 512]
 
     initializer "serviceworker-rails.configure_rails_initialization", after: :load_config_initializers do
       config.serviceworker.logger ||= ::Rails.logger


### PR DESCRIPTION
Add extra icon sizes to satisfy [PWABuilder](https://www.pwabuilder.com/). 

These icons are generated automatically when using [App Image Generator](https://www.pwabuilder.com/imageGenerator).