### PR TITLE
Proxy requests to the webpack-dev-server

### DIFF
--- a/lib/serviceworker/handlers/webpacker_handler.rb
+++ b/lib/serviceworker/handlers/webpacker_handler.rb
@@ -11,7 +11,12 @@ module ServiceWorker
 
         path = Webpacker.manifest.lookup(path_info)
 
-        file_server.call(env.merge("PATH_INFO" => path))
+        if Webpacker.dev_server.running?
+          proxy = Webpacker::DevServerProxy.new
+          proxy.call(env.merge("PATH_INFO" => path))
+        else
+          file_server.call(env.merge("PATH_INFO" => path))
+        end
       end
 
       private


### PR DESCRIPTION
Hi @rossta 

I've been playing around for ages trying to fix #50. I got this far - it works for most use cases but not if `hmr` is set in the webpacker config, because of https://github.com/webpack/webpack/issues/6642 , which apparently does affect 3.x but the option to change the name of 'window' isn't available until webpack 4.x.

I appreciate that makes this only a partial fix so please do feel free to reject this PR, especially as I went back to sprockets myself so it's not being used in any of my code.