### PR TITLE
Make it possible to override Cache-Control

### DIFF
--- a/lib/serviceworker/middleware.rb
+++ b/lib/serviceworker/middleware.rb
@@ -20,7 +20,7 @@ module ServiceWorker
     def initialize(app, opts = {})
       @app = app
       @opts = opts
-      @headers = opts.fetch(:headers, {}).merge(default_headers)
+      @headers = default_headers.merge(opts.fetch(:headers, {}))
       @router = opts.fetch(:routes, ServiceWorker::Router.new)
       @handler = Handlers.build(@opts.fetch(:handler, nil))
     end

--- a/test/serviceworker/rack_integration_test.rb
+++ b/test/serviceworker/rack_integration_test.rb
@@ -10,6 +10,8 @@ class ServiceWorker::RackIntegrationTest < Minitest::Test
   def router
     ServiceWorker::Router.new do
       match "/serviceworker.js" => "assets/serviceworker.js"
+      match "/cacheable-serviceworker.js" => "assets/serviceworker.js",
+            headers: { "Cache-Control" => "public, max-age=12345" }
     end
   end
 
@@ -33,5 +35,11 @@ class ServiceWorker::RackIntegrationTest < Minitest::Test
     assert_equal "application/javascript", last_response.headers["Content-Type"]
     assert_equal "private, max-age=0, no-cache", last_response.headers["Cache-Control"]
     assert_match(/console.log\(.*'Hello from Rack ServiceWorker!'.*\);/, last_response.body)
+  end
+
+  def test_cacheable_route
+    get "/cacheable-serviceworker.js"
+
+    assert_equal "public, max-age=12345", last_response.headers["Cache-Control"]
   end
 end


### PR DESCRIPTION
#### TLDR
* I want to override `Cache-Control` but can't, so I changed `default_headers` merge precedence to allow it

#### Reviewer asks
* Is it OK to keep the header override check in `rack_integration_test.rb`?
  - If not, how can I repro the non-override behavior in `rails_integration_test.rb`?

#### Details
Hi! I know it's advised not to cache the service-worker requests, but we have a case where we it's more desirable to prevent it from piercing our reverse-proxying CDN on Cloudflare than to have a guarantee the worker script is always up-to-date.

Trying to make that work I hit a problem with the way `opts` were merged into `default_headers`. `default_headers` took precedence and we could never override `Cache-Control`.

This PR proposes changing that.

I tried to include a test, initially in `rails_integration_test.rb`, but couldn't really reproduce the merge precedence problem, not sure why, maybe those tests don't go through the middleware initialization somehow?

I reproduced it successfully in `rack_integration_test.rb`, but from the looks of it I imagine it's intended as more of a smoke test setup then a place for validating features. Let me know if keeping it there is OK.