### PR TITLE
Detect First Matching Pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ cache:
   directories:
     - node_modules
 rvm:
-  - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 before_install:
   - gem update --system
   - gem install bundler

--- a/lib/serviceworker/router.rb
+++ b/lib/serviceworker/router.rb
@@ -51,10 +51,7 @@ module ServiceWorker
 
     def match_route(env)
       path = env[PATH_INFO]
-      @routes.each do |route|
-        match = route.match(path) and return match
-      end
-      nil
+      @routes.lazy.map { |route| route.match(path) }.detect(&:itself)
     end
   end
 end

--- a/serviceworker-rails.gemspec
+++ b/serviceworker-rails.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "railties", [">= 3.1"]
 
+  spec.required_ruby_version = "~> 2.2"
+
   spec.add_development_dependency "sprockets-rails"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 11.0"


### PR DESCRIPTION
While debugging my own Serviceworker-Rails configuration, I ran across `Router#match_route` and was quite confused by the early-returning `each` block. It took me a while to think through what was going on, and realize it was the magic of the early return.

I thought maybe we could clean that code up a bit by leveraging lazy enumerable and `Object#itself`, both available since Ruby 2.2.

_Semi-related_ - I went ahead and made Ruby 2.2 a minimum requirement, despite it being EoL'd a year ago.

Thoughts?