### PR TITLE
Fix Rake::File deprecation warning

### DIFF
--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -92,7 +92,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)

--- a/lib/serviceworker/handlers/rack_handler.rb
+++ b/lib/serviceworker/handlers/rack_handler.rb
@@ -18,7 +18,7 @@ module ServiceWorker
       end
 
       def file_server
-        @file_server ||= ::Rack::File.new(@root)
+        @file_server ||= ::Rack::Files.new(@root)
       end
     end
   end

--- a/lib/serviceworker/handlers/sprockets_handler.rb
+++ b/lib/serviceworker/handlers/sprockets_handler.rb
@@ -22,7 +22,7 @@ module ServiceWorker
       end
 
       def file_server
-        @file_server ||= ::Rack::File.new(::Rails.public_path)
+        @file_server ||= ::Rack::Files.new(::Rails.public_path)
       end
 
       def config

--- a/lib/serviceworker/handlers/sprockets_handler.rb
+++ b/lib/serviceworker/handlers/sprockets_handler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rack/file"
+require "rack/files"
 
 module ServiceWorker
   module Handlers

--- a/lib/serviceworker/handlers/webpacker_handler.rb
+++ b/lib/serviceworker/handlers/webpacker_handler.rb
@@ -22,7 +22,7 @@ module ServiceWorker
       private
 
       def file_server
-        @file_server ||= ::Rack::File.new(::Rails.public_path)
+        @file_server ||= ::Rack::Files.new(::Rails.public_path)
       end
     end
   end

--- a/lib/serviceworker/handlers/webpacker_handler.rb
+++ b/lib/serviceworker/handlers/webpacker_handler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rack/file"
+require "rack/files"
 require "webpacker"
 
 module ServiceWorker


### PR DESCRIPTION
Replace `Rake::File` with `Rake::Files` to fix the following deprecation warning:
`Rack::File is deprecated and will be removed in Rack 3.1`