### PR TITLE
Fix Rails 7.1 env[PATH_INFO] for root path

### DIFF
--- a/lib/serviceworker/router.rb
+++ b/lib/serviceworker/router.rb
@@ -51,6 +51,7 @@ module ServiceWorker
 
     def match_route(env)
       path = env[PATH_INFO]
+      path = '/' if path == ''
       @routes.lazy.map { |route| route.match(path) }.detect(&:itself)
     end
   end


### PR DESCRIPTION
before rails 7.0 env[PATH_INFO] was '/' for root_path, now it is a blank string