### PR TITLE
Add trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    # If you configured a GitHub environment on RubyGems, you must use it here.
+    environment: release
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
Adds a GitHub Actions release workflow that uses RubyGems trusted publishing via oidc/id-token permissions and rubygems/release-gem@v1.