### PR TITLE
Fix blank PATH_INFO root matching

### DIFF
--- a/lib/serviceworker/router.rb
+++ b/lib/serviceworker/router.rb
@@ -53,7 +53,7 @@ module ServiceWorker
 
     def match_route(env)
       path = env[PATH_INFO]
-      path = '/' if path == ''
+      path = "/" if path == ""
       @routes.lazy.map { |route| route.match(path) }.detect(&:itself)
     end
   end

--- a/lib/serviceworker/router.rb
+++ b/lib/serviceworker/router.rb
@@ -53,6 +53,7 @@ module ServiceWorker
 
     def match_route(env)
       path = env[PATH_INFO]
+      path = '/' if path == ''
       @routes.lazy.map { |route| route.match(path) }.detect(&:itself)
     end
   end

--- a/test/serviceworker/router_test.rb
+++ b/test/serviceworker/router_test.rb
@@ -63,6 +63,15 @@ class ServiceWorker::RouterTest < Minitest::Test
     assert_equal [path, asset_name, headers], ["/bar", "bar", {}]
   end
 
+  def test_match_route_treats_blank_root_path_as_slash
+    @router.draw do
+      match "/"
+    end
+
+    path, asset_name, headers, _ = @router.match_route("PATH_INFO" => "").to_a
+    assert_equal [path, asset_name, headers], ["/", "", {}]
+  end
+
   def test_match_route_doesnt_match
     @router.draw do
       match "/foo"


### PR DESCRIPTION
This rebases the Rails 7.1 root-path fix onto main and includes a regression test for blank PATH_INFO at the root route.